### PR TITLE
Creates method to add Categories to specific Supplement

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+class Category < ApplicationRecord
+  validates_presence_of :keyword
+  belongs_to :supplement
+end

--- a/app/models/supplement.rb
+++ b/app/models/supplement.rb
@@ -1,4 +1,45 @@
 class Supplement < ApplicationRecord
-  serialize :categories, Array
-  validates_presence_of :title, :summary, :categories
+  validates_presence_of :title, :summary
+  has_many :categories
+
+  def self.add_benefit_categories(keyword, supplement)
+    supplement_benefits = WebParser.get_benefits(keyword)
+    supplement_benefits.each do |bulk_benefit|
+      categories.each do |key, value|
+        key.each do |our_benefit|
+          if bulk_benefit.include?(our_benefit)
+            supplement.categories.find_or_create_by(keyword: value)
+          end
+        end
+      end
+    end
+  end
+
+  def self.categories
+    {
+      ['increased muscle mass'] => 'muscle mass',
+      ['muscle mass'] => 'muscle mass',
+      ['weight gain'] => 'weight gain',
+      ['anaerobic strength'] => 'anaerobic strength',
+      ['brain', 'cognitive', 'focus', 'mental', 'memory'] => 'nootropic',
+      ['energy'] => 'energy',
+      ['endurance'] => 'endurance',
+      ['exercise performance', 'performance'] => 'exercise performance',
+      ['overall health', 'overall wellness'] => 'overall health',
+      ['antioxidant'] => 'antioxidant',
+      ['digestive'] => 'digestive health',
+      ['heart', 'cardiovascular'] => 'heart health',
+      ['hair'] => 'hair health',
+      ['skin'] => 'skin health',
+      ['immune', 'immunity'] => 'immunity boost',
+      ['healthy weight'] => 'weight maintenace',
+      ['circulatory system'] => 'blood flow',
+      ['mood support'] => 'mood',
+      ['increased appetite'] => 'appetite increaser',
+      ['sexual'] => 'sexual health',
+      ['respiratory'] => 'respiratory',
+      ['bones'] => 'bone strength',
+      ['joint'] => 'joint strength'
+    }
+  end
 end

--- a/db/migrate/20210412225410_create_supplement.rb
+++ b/db/migrate/20210412225410_create_supplement.rb
@@ -3,7 +3,6 @@ class CreateSupplement < ActiveRecord::Migration[5.2]
     create_table :supplements do |t|
       t.string :title
       t.string :summary
-      t.text :categories, :default => [].to_yaml
     end
   end
 end

--- a/db/migrate/20210413221540_create_category.rb
+++ b/db/migrate/20210413221540_create_category.rb
@@ -1,0 +1,7 @@
+class CreateCategory < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :keyword
+    end
+  end
+end

--- a/db/migrate/20210413221640_add_supplements_to_categories.rb
+++ b/db/migrate/20210413221640_add_supplements_to_categories.rb
@@ -1,0 +1,5 @@
+class AddSupplementsToCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :categories, :supplement, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_12_225410) do
+ActiveRecord::Schema.define(version: 2021_04_13_221640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "categories", force: :cascade do |t|
+    t.string "keyword"
+    t.bigint "supplement_id"
+    t.index ["supplement_id"], name: "index_categories_on_supplement_id"
+  end
+
   create_table "supplements", force: :cascade do |t|
     t.string "title"
     t.string "summary"
-    t.text "categories", default: "--- []\n"
   end
 
+  add_foreign_key "categories", "supplements"
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  describe 'validations' do
+    it {should validate_presence_of :keyword }
+  end
+  describe 'relationships' do
+    it { should belong_to :supplement }
+  end
+end

--- a/spec/models/supplement_spec.rb
+++ b/spec/models/supplement_spec.rb
@@ -4,6 +4,22 @@ RSpec.describe Supplement, type: :model do
   describe 'validations' do
     it { should validate_presence_of :title }
     it { should validate_presence_of :summary }
-    it { should validate_presence_of :categories }
+  end
+  describe 'relationships' do
+    it { should have_many :categories }
+  end
+  describe 'methods' do
+    it 'add_benefit_categories()' do
+      keyword = 'creatine-monohydrate'
+      supp = Supplement.create!(title: WebParser.get_title(keyword), summary: WebParser.get_summary(keyword))
+      expect(supp.categories).to be_empty
+      Supplement.add_benefit_categories(keyword, supp)
+      expect(supp.categories).to_not be_empty
+      expect(supp.categories.count).to eq(4)
+      expected_benefits = ['muscle mass', 'weight gain', 'anaerobic strength', 'nootropic']
+      expected_benefits.each do |benefit|
+        expect(supp.categories.pluck(:keyword).include?(benefit)).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
This one does a lot of cool stuff.

- It creates an ActiveRecord (SQL) class of `Category`
- A `Supplement` can have many categories, and a`Category` belongs to a `Supplement`
- The `Supplement` class has a method called `add_benefit_categories()` where it does the following:
1. It'll take a keyword like 'creatine-monohydrate' and search through our predetermined categories and, using the listed benefits from BulkSupplements, it'll find which benefit it corresponds to, then make a `Category` using that benefits' name and relating it to the original supplement in question. BUT it **will not** create duplicate categories for one `Supplement`. That's the `find_or_create_by()` ActiveRecord method you see (marked it below)