### PR TITLE
Refactor index and show page, create & pass test for related suppleme…

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,3 +22,11 @@
   margin-left: -120px;
   margin-bottom: 10px;
 }
+
+.supplement-categories-div {
+  width: 100%;
+}
+
+.category-button {
+  margin: auto 0;
+}

--- a/app/controllers/supplements_controller.rb
+++ b/app/controllers/supplements_controller.rb
@@ -1,9 +1,13 @@
 class SupplementsController < ApplicationController
   def index
-    @all_supplements = Supplement.all
+    @all_supplements = Supplement.order(:title)
   end
 
   def show
     @supp = Supplement.find_by(id: params['id'].to_i)
+  end
+
+  def search
+    @related_supplements = Supplement.related_supplements(params['id'], params['keyword'])
   end
 end

--- a/app/models/supplement.rb
+++ b/app/models/supplement.rb
@@ -32,6 +32,15 @@ class Supplement < ApplicationRecord
     end
   end
 
+  def self.related_supplements(id, keyword)
+    category = Category.find(id.to_i)
+    related_supplements = Supplement.joins(:categories).where(categories: {keyword: keyword})
+    {
+      keyword: keyword,
+      related_supplements: related_supplements
+    }
+  end
+
   private
 
   def self.categories

--- a/app/views/supplements/index.html.erb
+++ b/app/views/supplements/index.html.erb
@@ -19,8 +19,10 @@
             <% else %>
               <% if index == 0 %>
                 <%= category.keyword.capitalize %>,
-              <% else %>
+              <% elsif category != supplement.categories[-1] %>
                 <%= category.keyword %>,
+              <% else %>
+                <%= category.keyword %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/supplements/search.html.erb
+++ b/app/views/supplements/search.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>Related Supplements</title>
+  </head>
+  <body>
+    <%x = 0 %>
+    <h1>All supplements related to <%= @related_supplements[:keyword] %>...</h1>
+    <% @related_supplements[:related_supplements].each do |supplement| %>
+      <div class="related_supplement-<%=x%>">
+
+        <form class="supplement" action="/supplements" method="post">
+          <label for="id" class="hidden"></label>
+          <input type="text" name="id" class="hidden" value="<%=supplement.id%>">
+          <input type="submit" name="" class="supplement-button" value="<%=supplement.title%>">
+            <hr>
+          </form>
+        </div>
+        <%x += 1 %>
+    <% end %>
+
+  </body>
+</html>

--- a/app/views/supplements/show.html.erb
+++ b/app/views/supplements/show.html.erb
@@ -5,8 +5,22 @@
     <title></title>
   </head>
   <body>
-    <%= @supp.title %>
-    <br><br>
-    <%= @supp.summary %>
+    <div class="supplement-info">
+      <%= @supp.title %>
+      <br><br>
+      <%= @supp.summary %>
+      <p>Click a benefit below to see other supplements with the same benefit:</p>
+      <div class="supplement-categories-div">
+        <% @supp.categories.each do |category| %>
+        <form class="supplement-categories" action="/search" method="post">
+          <label for="id" class="hidden"></label>
+          <input type="text" name="id" class="hidden" value="<%=category.id%>">
+          <input type="text" name="keyword" class="hidden" value="<%=category.keyword%>">
+          <input type="submit" name="" class="category-button" value="<%=category.keyword.capitalize%>">
+        </form>
+        <% end %>
+
+      </div>
+    </div>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   get '/supplements', to: 'supplements#index'
   post '/supplements', to: 'supplements#show'
   get '/test', to: 'supplements#test'
+  post '/search', to: 'supplements#search'
 end

--- a/spec/database/supplement_spec.rb
+++ b/spec/database/supplement_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Supplement, type: :model do
       expect(Supplement.count).to eq(403)
     end
     it 'supplements should have categories' do
-      require "pry"; binding.pry
       expect(Supplement.first.categories).to_not be_empty
       expect(Supplement.last.categories).to_not be_empty
       expect(Supplement.last.title).to eq('Zinc Oxide Powder')

--- a/spec/features/supplement_view_spec.rb
+++ b/spec/features/supplement_view_spec.rb
@@ -1,11 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe 'Supplment view page' do
-   it 'can do' do
+   it 'index pages' do
      visit ('/supplements')
      number = (1..402).to_a
      number.each do |num|
        expect(page).to have_css(".supplement-#{num}")
      end
+  end
+  it 'show page' do
+    visit('/supplements')
+    click_button('L-Citrulline DL-Malate 2:1 Powder')
+    expect(page).to have_css('.category-button')
+  end
+
+  it 'show page related supplements buttons' do
+    visit('/supplements')
+    click_button('L-Citrulline DL-Malate 2:1 Powder')
+
+    click_button('Energy')
+    expect(current_path).to eq('/search')
+    expect(page).to have_button('Caffeine Pills')
   end
 end


### PR DESCRIPTION
This is something I've been waiting to do for this project since we started talking about it.

When one clicks on a `Supplement` on the supplements index page, they're re-routed to a show page where they can see a detailed description of the `Supplement`. On that page there are buttons underneath the description with the categories that `Supplement` is has ('energy', 'mood', etc.). If you click one of the category buttons, you're taken to a `/search` page where it'll display all other `Supplements` that have that specific `Category` as well.
